### PR TITLE
Add visionOS support

### DIFF
--- a/src/pbxproj/object/target/platform.rs
+++ b/src/pbxproj/object/target/platform.rs
@@ -17,6 +17,9 @@ pub enum PBXTargetPlatform {
     /// macOS Platform
     #[serde(rename = "macOS")]
     MacOS,
+    /// visionOS Platform
+    #[serde(rename = "xrOS")]
+    XrOS,
     /// Unknown or not support platform
     Unknown,
 }
@@ -35,6 +38,7 @@ impl PBXTargetPlatform {
             "macosx" => Self::MacOS,
             "appletvos" => Self::TvOS,
             "watchos" => Self::WatchOS,
+            "xros" => Self::XrOS,
             _ => Self::Unknown,
         }
     }
@@ -61,6 +65,7 @@ impl FromStr for PBXTargetPlatform {
             "watchOS" => Ok(Self::WatchOS),
             "tvOS" => Ok(Self::TvOS),
             "macOS" => Ok(Self::MacOS),
+            "xrOS" => Ok(Self::XrOS),
             _ => Ok(Self::Unknown),
         }
     }
@@ -73,6 +78,7 @@ impl ToString for PBXTargetPlatform {
             Self::WatchOS => "watchOS",
             Self::TvOS => "tvOS",
             Self::MacOS => "macOS",
+            Self::XrOS => "xrOS",
             _ => "",
         }
         .into()


### PR DESCRIPTION
Hi @kkharji!

I'm currently trying to add visionOS support to the xbase Neovim plugin. See the corresponding draft PR [here](https://github.com/kkharji/xbase/pull/245). 

The problem is that I'm still getting the following error when trying to open the [Apple Vision Pro Hello World project](https://developer.apple.com/documentation/visionos/world).

```
Setup [Avp-HelloWorld] Failed to setup project: Parse content
```

I presume that this has to do with pest not knowing about some node in `project.pbxproj`? Do you have any pointers on how I could debug this further?