### PR TITLE
Added visionOS. Fixed grammar for CocoaPods projects

### DIFF
--- a/src/pbxproj/object/collection.rs
+++ b/src/pbxproj/object/collection.rs
@@ -151,7 +151,7 @@ impl PBXObjectCollection {
     /// Get All XCSwiftPackageProductDependency Objects
     pub fn swift_package_product_dependencies<'a>(
         &'a self,
-    ) -> Vec<XCSwiftPackageProductDependency> {
+    ) -> Vec<XCSwiftPackageProductDependency<'a>> {
         self.get_vec_by(|(_, v)| {
             v.get_kind("isa")
                 .map(|k| k.is_xc_swift_package_product_dependency())
@@ -160,7 +160,7 @@ impl PBXObjectCollection {
     }
 
     /// Get All XCRemoteSwiftPackageReference Objects
-    pub fn swift_package_references<'a>(&'a self) -> Vec<XCRemoteSwiftPackageReference> {
+    pub fn swift_package_references<'a>(&'a self) -> Vec<XCRemoteSwiftPackageReference<'a>> {
         self.get_vec_by(|(_, v)| {
             v.get_kind("isa")
                 .map(|k| k.is_xc_remote_swift_package_reference())
@@ -169,32 +169,32 @@ impl PBXObjectCollection {
     }
 
     /// Get PBXTarget
-    pub fn get_target<'a>(&'a self, key: &str) -> Option<PBXTarget> {
+    pub fn get_target<'a>(&'a self, key: &str) -> Option<PBXTarget<'a>> {
         self.get(key)
     }
 
     /// Get PBXBuildPhase
-    pub fn get_build_phase<'a>(&'a self, key: &str) -> Option<PBXBuildPhase> {
+    pub fn get_build_phase<'a>(&'a self, key: &str) -> Option<PBXBuildPhase<'a>> {
         self.get(key)
     }
 
     /// Get PBXBuildFile
-    pub fn get_build_file<'a>(&'a self, key: &str) -> Option<PBXBuildFile> {
+    pub fn get_build_file<'a>(&'a self, key: &str) -> Option<PBXBuildFile<'a>> {
         self.get(key)
     }
 
     /// Get PBXBuildRule
-    pub fn get_build_rule<'a>(&'a self, key: &str) -> Option<PBXBuildRule> {
+    pub fn get_build_rule<'a>(&'a self, key: &str) -> Option<PBXBuildRule<'a>> {
         self.get(key)
     }
 
     /// Get PBXProject
-    pub fn get_project<'a>(&'a self, key: &str) -> Option<PBXProject> {
+    pub fn get_project<'a>(&'a self, key: &str) -> Option<PBXProject<'a>> {
         self.get(key)
     }
 
     /// Get all files
-    pub fn get_file<'a>(&'a self, key: &str) -> Option<PBXFSReference> {
+    pub fn get_file<'a>(&'a self, key: &str) -> Option<PBXFSReference<'a>> {
         let fs_ref = self.get::<PBXFSReference, _>(key)?;
         if fs_ref.is_file() {
             Some(fs_ref)
@@ -204,7 +204,7 @@ impl PBXObjectCollection {
     }
 
     /// Get all files
-    pub fn get_group<'a>(&'a self, key: &str) -> Option<PBXFSReference> {
+    pub fn get_group<'a>(&'a self, key: &str) -> Option<PBXFSReference<'a>> {
         let fs_ref = self.get::<PBXFSReference, _>(key)?;
         if fs_ref.is_group() {
             Some(fs_ref)
@@ -214,7 +214,7 @@ impl PBXObjectCollection {
     }
 
     /// Get fs object
-    pub fn get_fs_object<'a>(&'a self, key: &str) -> Option<PBXFSReference> {
+    pub fn get_fs_object<'a>(&'a self, key: &str) -> Option<PBXFSReference<'a>> {
         self.get(key)
     }
 
@@ -222,7 +222,7 @@ impl PBXObjectCollection {
     pub fn get_group_by_name_or_path<'a, S: AsRef<str>>(
         &'a self,
         name_or_path: S,
-    ) -> Option<PBXFSReference> {
+    ) -> Option<PBXFSReference<'a>> {
         let name = name_or_path.as_ref();
         self.groups().into_iter().find(|o| {
             if let Some(n) = o.name {
@@ -255,7 +255,7 @@ impl PBXObjectCollection {
     pub fn get_swift_package_product_dependency<'a>(
         &'a self,
         key: &str,
-    ) -> Option<XCSwiftPackageProductDependency> {
+    ) -> Option<XCSwiftPackageProductDependency<'a>> {
         self.get(key)
     }
 
@@ -263,12 +263,12 @@ impl PBXObjectCollection {
     pub fn get_swift_package_reference<'a>(
         &'a self,
         key: &str,
-    ) -> Option<XCRemoteSwiftPackageReference> {
+    ) -> Option<XCRemoteSwiftPackageReference<'a>> {
         self.get(key)
     }
 
     /// Get PBXTarget by the target name
-    pub fn get_target_by_name<'a>(&'a self, name: &'a str) -> Option<PBXTarget> {
+    pub fn get_target_by_name<'a>(&'a self, name: &'a str) -> Option<PBXTarget<'a>> {
         self.targets().into_iter().find(|target| {
             if let Some(target_name) = target.name {
                 target_name == name

--- a/src/pbxproj/object/swift_package/version.rs
+++ b/src/pbxproj/object/swift_package/version.rs
@@ -6,7 +6,7 @@ use tap::Pipe;
 /// [`XCRemoteSwiftPackageReference`] version rules.
 ///
 /// [`XCRemoteSwiftPackageReference`]: crate::pbxproj::XCRemoteSwiftPackageReference
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum XCVersionRequirement {
     /// Version can be bumped up to the next major version.
     UpToNextMajorVersion(String),

--- a/src/pbxproj/object/swift_package/version.rs
+++ b/src/pbxproj/object/swift_package/version.rs
@@ -31,7 +31,7 @@ impl TryFrom<&PBXValue> for XCVersionRequirement {
             .ok_or_else(|| anyhow::anyhow!("Can get XCVersionRequirement for non object type"))?;
         let key = map.try_get_string("kind")?;
         match key.as_str() {
-            "bracnh" => Self::Branch(map.try_get_string(&key)?.to_string()),
+            "branсh" => Self::Branch(map.try_get_string(&key)?.to_string()),
             "revision" => Self::Revision(map.try_get_string(&key)?.to_string()),
             "exactVersion" => Self::Exact(map.try_get_string("version")?.to_string()),
             "versionRange" => {
@@ -44,8 +44,8 @@ impl TryFrom<&PBXValue> for XCVersionRequirement {
                 Self::UpToNextMinorVersion(min.to_string())
             }
             "upToNextMajorVersion" => {
-                let max = map.try_get_string("maximumVersion")?;
-                Self::UpToNextMajorVersion(max.to_string())
+                let min = map.try_get_string("minimumVersion")?;
+                Self::UpToNextMajorVersion(min.to_string())
             }
             k => bail!("Unkown kind {k}"),
         }
@@ -59,7 +59,7 @@ impl From<XCVersionRequirement> for PBXValue {
         match value {
             XCVersionRequirement::UpToNextMajorVersion(v) => {
                 collect.insert("kind".to_string(), "upToNextMajorVersion".into());
-                collect.insert("maximumVersion".to_string(), v.into());
+                collect.insert("minimumVersion".to_string(), v.into());
             }
             XCVersionRequirement::UpToNextMinorVersion(v) => {
                 collect.insert("kind".to_string(), "upToNextMinorVersion".into());

--- a/src/pbxproj/object/target/platform.rs
+++ b/src/pbxproj/object/target/platform.rs
@@ -17,6 +17,9 @@ pub enum PBXTargetPlatform {
     /// macOS Platform
     #[serde(rename = "macOS")]
     MacOS,
+    /// visionOS Platform
+    #[serde(rename = "xrOS")]
+    XrOS,
     /// Unknown or not support platform
     Unknown,
 }
@@ -35,6 +38,7 @@ impl PBXTargetPlatform {
             "macosx" => Self::MacOS,
             "appletvos" => Self::TvOS,
             "watchos" => Self::WatchOS,
+            "xros" => Self::XrOS,
             _ => Self::Unknown,
         }
     }
@@ -61,6 +65,7 @@ impl FromStr for PBXTargetPlatform {
             "watchOS" => Ok(Self::WatchOS),
             "tvOS" => Ok(Self::TvOS),
             "macOS" => Ok(Self::MacOS),
+            "xrOS" => Ok(Self::XrOS),
             _ => Ok(Self::Unknown),
         }
     }
@@ -73,6 +78,7 @@ impl ToString for PBXTargetPlatform {
             Self::WatchOS => "watchOS",
             Self::TvOS => "tvOS",
             Self::MacOS => "macOS",
+            Self::XrOS => "xrOS",
             _ => "",
         }
         .into()

--- a/src/pbxproj/pest/grammar.pest
+++ b/src/pbxproj/pest/grammar.pest
@@ -19,10 +19,10 @@ bool    = { (^"YES" | ^"NO") ~ !"_" ~ !ASCII_ALPHANUMERIC }
 number  = @{ ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)* ~ !ASCII_ALPHA }
 string  = @{ "\"" ~ INNER_STRING ~ "\"" }
 ident   = @{
-  (ASCII_ALPHA | ASCII_DIGIT | "_" | ("." | "/")* ~ ASCII_ALPHA{2}) ~ (ASCII_ALPHA | ASCII_DIGIT | "_" | "." | "/")*
+  (ASCII_ALPHA | ASCII_DIGIT | "_" | "." | ("." | "/")* ~ ASCII_ALPHA{2}) ~ (ASCII_ALPHA | ASCII_DIGIT | "_" | "." | "/")*
 }
 uuid    = @{
-  (ASCII_ALPHA{1} | ASCII_DIGIT{1}) ~ ASCII_ALPHANUMERIC{23} ~ !(ASCII_ALPHA | ".")
+  (ASCII_ALPHA{1} | ASCII_DIGIT{1}) ~ ASCII_ALPHANUMERIC{23,31} ~ !(ASCII_ALPHA | ".")
 }
 kind    = @{
      "PBXBuildFile"


### PR DESCRIPTION
Couple of fixes:
1. Added xrOS enum case.
2. Ident can have simple `.` value (root folder).
3. CocoaPods generates 32 char UUIDs. Added to grammar.
4. Fixed SPM reference version parsing
5. Fixed some warnings

Fixes:  #9 , replaces: #7 